### PR TITLE
Fix login redirect view and add auth redirect test

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,7 @@ from flask_login import LoginManager
 
 db = SQLAlchemy()
 login_manager = LoginManager()
-login_manager.login_view = 'login'
+login_manager.login_view = 'main.login'
 
 
 def create_app():

--- a/tests/test_auth_redirect.py
+++ b/tests/test_auth_redirect.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app import create_app, db
+
+
+class AuthRedirectTestCase(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app()
+        self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+        self.app.config['TESTING'] = True
+        self.client = self.app.test_client()
+        with self.app.app_context():
+            db.create_all()
+
+    def tearDown(self):
+        with self.app.app_context():
+            db.drop_all()
+
+    def test_login_required_redirect(self):
+        response = self.client.get('/portal')
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.headers['Location'].endswith('/login?next=%2Fportal'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_reservation.py
+++ b/tests/test_reservation.py
@@ -1,5 +1,9 @@
+import os
+import sys
 import unittest
 from datetime import date
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from app import create_app, db
 from app.models import User, Reservation, is_available


### PR DESCRIPTION
## Summary
- point login manager at `main.login` to correctly handle unauthorized redirects
- add test covering redirect to `/login`
- configure tests to locate the app package during import

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d02b4c1f08325a3e6ff8dfd80947c